### PR TITLE
Redirect root to auth

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -66,6 +66,11 @@ export function registerRoutes(app: Express): Server {
   // Serve uploaded files
   app.use('/uploads', express.static(uploadDir));
 
+  // Redirect the site root to the auth page
+  app.get('/', (_req, res) => {
+    res.redirect('/auth');
+  });
+
   // Project routes
   app.get("/api/projects", requireAuth, async (req, res) => {
     try {


### PR DESCRIPTION
## Summary
- redirect `/` to `/auth`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_685b50f02bfc8327a9079fbdcb083033